### PR TITLE
Update ClientAdapter.php

### DIFF
--- a/src/ClientAdapters/ClientAdapter.php
+++ b/src/ClientAdapters/ClientAdapter.php
@@ -55,12 +55,13 @@ abstract class ClientAdapter implements ClientAdapterInterface
 
         $paramOut = '';
         foreach ($parameters as $key=>$value) {
-            $paramOut = $key.'=';
+            $paramOut .= $key.'=';
             if (is_array($value)){
                 $paramOut .= join(',', $value);
             }else{
                 $paramOut .= $value;
             }
+            $paramOut .= '&';
         }
 
         return $paramOut;


### PR DESCRIPTION
$paramOut gets overwritten and thus gives invalid urls when using more than 1 parameter.